### PR TITLE
Version API routes and migrate user profile to /users/me

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -24,7 +24,7 @@ def create_app():
     from app.models.character_equipment import CharacterEquipment
 
 
-    app.register_blueprint(auth_bp, url_prefix="/auth")
-    app.register_blueprint(user_bp, url_prefix="/users")
+    app.register_blueprint(auth_bp, url_prefix="/api/v1/auth")
+    app.register_blueprint(user_bp, url_prefix="/api/v1/users")
 
     return app

--- a/backend/app/handlers/user_handler.py
+++ b/backend/app/handlers/user_handler.py
@@ -1,14 +1,18 @@
-from flask import jsonify, request
-from app.services.user_service import get_user_profile
+from flask import jsonify
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
 from app.services.auth_service import ServiceError
+from app.services.user_service import get_user_profile
 
 
-def get_user_handler(user_id):
-	try:
-		profile = get_user_profile(user_id)
-		return jsonify(profile), 200
-	except ServiceError as e:
-		return jsonify({"error": str(e)}), e.status_code
-	except Exception:
-		return jsonify({"error": "Internal server error"}), 500
+@jwt_required()
+def get_current_user_handler():
+    user_id = get_jwt_identity()
 
+    try:
+        profile = get_user_profile(user_id)
+        return jsonify(profile), 200
+    except ServiceError as e:
+        return jsonify({"error": str(e)}), e.status_code
+    except Exception:
+        return jsonify({"error": "Internal server error"}), 500

--- a/backend/app/routes/user_routes.py
+++ b/backend/app/routes/user_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint
-from app.handlers.user_handler import get_user_handler
+
+from app.handlers.user_handler import get_current_user_handler
 
 user_bp = Blueprint("user", __name__)
 
-user_bp.route("/<string:user_id>", methods=["GET"])(get_user_handler)
+user_bp.route("/me", methods=["GET"])(get_current_user_handler)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -18,12 +18,33 @@ def get_user_profile(user_id):
 	if user.party:
 		party = user.party
 		characters = []
-		for entry in party.characters:
-			ch = getattr(entry, "character", entry)
+		for ch in party.characters:
+			current_job = None
+			if ch.current_job:
+				current_job = {
+					"id": ch.current_job.id,
+					"name": ch.current_job.name,
+					"icon": ch.current_job.icon,
+				}
+
+			equipped_items = []
+			for relation in ch.equipment:
+				equipment = relation.equipment
+				equipped_items.append({
+					"slot": relation.slot,
+					"equipment": {
+						"id": equipment.id,
+						"name": equipment.name,
+						"type": equipment.type,
+						"rating": equipment.rating,
+					},
+				})
+
 			characters.append({
 				"id": ch.id,
 				"name": ch.name,
-				"party_slot": getattr(entry, "party_slot", None),
+				"current_job": current_job,
+				"equipped_items": equipped_items,
 			})
 
 		result["party"] = {

--- a/frontend-react/src/hooks/useAuth.js
+++ b/frontend-react/src/hooks/useAuth.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-const API_URL = "http://localhost:5000/auth";
+const API_URL = "http://localhost:5000/api/v1/auth";
 
 export function useAuth() {
   const [loading, setLoading] = useState(false);
@@ -28,7 +28,6 @@ export function useAuth() {
       if (contentType && contentType.includes("application/json")) {
         data = await res.json();
       } else {
-        const text = await res.text();
         throw {
           status: res.status,
           message: "Invalid server response",
@@ -71,7 +70,6 @@ export function useAuth() {
       if (contentType && contentType.includes("application/json")) {
         data = await res.json();
       } else {
-        const text = await res.text();
         throw new Error("Server answer invalid");
       }
 

--- a/frontend-react/src/hooks/useUser.js
+++ b/frontend-react/src/hooks/useUser.js
@@ -1,48 +1,49 @@
 import { useState, useEffect, useCallback } from "react";
 
-const API_URL = "http://localhost:5000/users";
+const API_URL = "http://localhost:5000/api/v1/users/me";
 
-export default function useUser(userId) {
+export default function useUser() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const fetchUser = useCallback(
-    async (signal) => {
-      if (!userId) return;
-      setLoading(true);
-      setError(null);
+  const fetchUser = useCallback(async (signal) => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
 
-      try {
-        const res = await fetch(`${API_URL}/${encodeURIComponent(userId)}`, {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-          signal,
-        });
+    setLoading(true);
+    setError(null);
 
-        if (!res.ok) {
-          const text = await res.text();
-          throw new Error(text || `Request failed with status ${res.status}`);
-        }
+    try {
+      const res = await fetch(API_URL, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        signal,
+      });
 
-        const payload = await res.json();
-        setData(payload);
-      } catch (err) {
-        if (err.name === "AbortError") return;
-        setError(err);
-      } finally {
-        setLoading(false);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Request failed with status ${res.status}`);
       }
-    },
-    [userId],
-  );
+
+      const payload = await res.json();
+      setData(payload);
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    if (!userId) return;
     const controller = new AbortController();
     fetchUser(controller.signal);
     return () => controller.abort();
-  }, [userId, fetchUser]);
+  }, [fetchUser]);
 
   const refetch = useCallback(() => {
     const controller = new AbortController();

--- a/frontend-react/src/pages/Home.jsx
+++ b/frontend-react/src/pages/Home.jsx
@@ -1,16 +1,13 @@
 import React from "react";
 import { Button, Avatar } from "@radix-ui/themes";
 import useUser from "../hooks/useUser";
-import getUserIdFromToken from "../utils/jwt";
 import CharacterCard from "../components/CharacterCard";
 import bgImage from "../assets/resources/bgImage.png";
 import headerlogo from "../assets/resources/header-logo.png";
 
 const Home = () => {
   const cards = [1, 2, 3, 4];
-  const { data: user } = useUser(
-    getUserIdFromToken(localStorage.getItem("token")),
-  );
+  const { data: user } = useUser();
   console.log("User data:", user);
   return (
     <div


### PR DESCRIPTION
### Motivation
- Standardize and version API endpoints by moving auth and user blueprints under `/api/v1` to prepare for future changes and backward-compatible evolution. 
- Remove the legacy `GET /users/<user_id>` pattern and force authenticated profile access via a single `GET /users/me` endpoint based on JWT identity to simplify access control and reduce client-side responsibility. 
- Update frontend integration so it uses the new versioned endpoints and sends the JWT as an `Authorization: Bearer <token>` header. 

### Description
- Updated backend blueprint prefixes to `app.register_blueprint(auth_bp, url_prefix="/api/v1/auth")` and `app.register_blueprint(user_bp, url_prefix="/api/v1/users")` in `backend/app/__init__.py`. 
- Replaced the parameterized user route with a single route `GET /me` in `backend/app/routes/user_routes.py` and simplified the handler to `@jwt_required()` `get_current_user_handler()` which calls `get_jwt_identity()` in `backend/app/handlers/user_handler.py`. 
- Enhanced `get_user_profile` in `backend/app/services/user_service.py` to serialize character `current_job` and `equipped_items` details for richer client data. 
- Updated frontend auth hook to point to `http://localhost:5000/api/v1/auth` in `frontend-react/src/hooks/useAuth.js`. 
- Reworked frontend user hook to fetch from `http://localhost:5000/api/v1/users/me` and include `Authorization: Bearer <token>` header, and adjusted `Home.jsx` to call the new `useUser()` signature without extracting the user id from the token. 

### Testing
- Ran backend compilation with `python -m compileall backend/app` which completed successfully. 
- Ran frontend lint with `npm --prefix frontend-react run lint` which completed successfully. 
- Attempted frontend build with `npm --prefix frontend-react run build` which failed in this environment due to a missing package (`@tailwindcss/vite`) unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c622d0f548330b05637d903a8bbfd)